### PR TITLE
Update .env.tmp

### DIFF
--- a/.env.tmp
+++ b/.env.tmp
@@ -19,10 +19,11 @@ WALRUS_PUBLISHER_TARGET=localhost:27183
 WALRUS_NODE_URL=https://localhost:9185
 
 # PagerDuty Integration Key
-PAGERDUTY_INTEGRATION_KEY=<your-pagerduty-key>
+PAGERDUTY_INTEGRATION_KEY=
 
 # Telegram Bot Token
-TELEGRAM_BOT_TOKEN=<your-telegram-bot-token>
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
 
 # Discord Webhook URL
-DISCORD_WEBHOOK_URL=<your-discord-webhook-url>
+DISCORD_WEBHOOK_URL=


### PR DESCRIPTION
Add required `TELEGRAM_CHAT_ID` and remove defaults for other alertmanager params to clean up errors in logs.