### PR TITLE
feat(grafana): optional .grafana.env via GRAFANA_ENV_FILE, overridable GF_GITHUB_PLUGINS

### DIFF
--- a/.env.tmp
+++ b/.env.tmp
@@ -30,3 +30,9 @@ DISCORD_WEBHOOK_URL=
 
 # Slack Integration
 SLACK_WEBHOOK_URL=
+
+# Optional Extensions to Grafana
+# Comma separated list of URLs to GitHub plugins to install. See grafana/entrypoint.sh for details
+# GF_GITHUB_PLUGINS=
+# Extended Grafana configuration file
+# GRAFANA_ENV_FILE=.grafana.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+.grafana.env
+.DS_Store

--- a/.grafana.env.tmp
+++ b/.grafana.env.tmp
@@ -1,0 +1,4 @@
+# Set custom parameters for Grafana
+# https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#override-configuration-with-environment-variables
+# GF_SERVER_ROOT_URL=
+# GF_SERVER_SERVE_FROM_SUB_PATH=

--- a/README.md
+++ b/README.md
@@ -63,11 +63,28 @@ DISCORD_WEBHOOK_URL=<your-discord-webhook-url>
 
 # Slack Integration
 SLACK_WEBHOOK_URL=<your-slack-webhook-url>
+
+# Optional Extensions to Grafana
+# Comma separated list of URLs to GitHub plugins to install. See [grafana/entrypoint.sh](./grafana/entrypoint.sh) for details
+# GF_GITHUB_PLUGINS=
+# Extended Grafana configuration file
+# GRAFANA_ENV_FILE=.grafana.env
 ```
 
 > **Note:** If your targets (`WALRUS_NODE_TARGET`, `WALRUS_AGGREGATOR_TARGET`, `WALRUS_PUBLISHER_TARGET`) are HTTPS endpoints, make sure to include the `https://` protocol explicitly in the variable, e.g., `WALRUS_NODE_TARGET=https://node.example.com`.
 
 ---
+
+#### (Optional) Grafana Customisation
+
+```bash
+cp .grafana.env.tmp .grafana.env
+```
+
+In your `.env` file, set `GRAFANA_ENV_FILE=.grafana.env` so that Compose loads it. Then edit the `.grafana.env` file to configure additional Grafana settings.
+
+Refer to the [Grafana configuration documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#override-configuration-with-environment-variables) for details.
+
 
 ### **4. Start the Services**
 

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -11,13 +11,15 @@ services:
       GF_SECURITY_ADMIN_USER: ${GF_SECURITY_ADMIN_USER}
       GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
       GF_SERVER_HTTP_PORT: ${GF_PORT:-3000}
-      GF_GITHUB_PLUGINS: "https://github.com/grafana/grafana-infinity-datasource/releases/download/v2.11.4/yesoreyeram-infinity-datasource-2.11.4.zip"
+      GF_GITHUB_PLUGINS: ${GF_GITHUB_PLUGINS:-"https://github.com/grafana/grafana-infinity-datasource/releases/download/v2.11.4/yesoreyeram-infinity-datasource-2.11.4.zip"}
       PROMETHEUS_URL: "http://${PROMETHEUS_TARGET:-localhost:9090}"
       ALERTMANAGER_URL: "http://${ALERTMANAGER_TARGET:-localhost:9093}"
       WALRUS_NODE_TARGET: ${WALRUS_NODE_TARGET:-}
       WALRUS_AGGREGATOR_TARGET: ${WALRUS_AGGREGATOR_TARGET:-}
       WALRUS_PUBLISHER_TARGET: ${WALRUS_PUBLISHER_TARGET:-}
       WALRUS_NODE_URL: ${WALRUS_NODE_URL}
+    env_file:
+      - ${GRAFANA_ENV_FILE:-/dev/null}
     volumes:
       - ./grafana/dashboards:/tmp/dashboards
       - ./grafana/provisioning:/etc/grafana/provisioning

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -11,7 +11,7 @@ services:
       GF_SECURITY_ADMIN_USER: ${GF_SECURITY_ADMIN_USER}
       GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
       GF_SERVER_HTTP_PORT: ${GF_PORT:-3000}
-      GF_GITHUB_PLUGINS: ${GF_GITHUB_PLUGINS:-"https://github.com/grafana/grafana-infinity-datasource/releases/download/v2.11.4/yesoreyeram-infinity-datasource-2.11.4.zip"}
+      GF_GITHUB_PLUGINS: ${GF_GITHUB_PLUGINS:-https://github.com/grafana/grafana-infinity-datasource/releases/download/v2.11.4/yesoreyeram-infinity-datasource-2.11.4.zip}
       PROMETHEUS_URL: "http://${PROMETHEUS_TARGET:-localhost:9090}"
       ALERTMANAGER_URL: "http://${ALERTMANAGER_TARGET:-localhost:9093}"
       WALRUS_NODE_TARGET: ${WALRUS_NODE_TARGET:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       GF_SECURITY_ADMIN_USER: ${GF_SECURITY_ADMIN_USER}
       GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
       GF_SERVER_HTTP_PORT: ${GF_PORT:-3000}
-      GF_GITHUB_PLUGINS: ${GF_GITHUB_PLUGINS:-"https://github.com/grafana/grafana-infinity-datasource/releases/download/v2.11.4/yesoreyeram-infinity-datasource-2.11.4.zip"}
+      GF_GITHUB_PLUGINS: ${GF_GITHUB_PLUGINS:-https://github.com/grafana/grafana-infinity-datasource/releases/download/v2.11.4/yesoreyeram-infinity-datasource-2.11.4.zip}
       PROMETHEUS_URL: "http://${PROMETHEUS_TARGET:-localhost:9090}"
       ALERTMANAGER_URL: "http://${ALERTMANAGER_TARGET:-localhost:9093}"
       WALRUS_NODE_TARGET: ${WALRUS_NODE_TARGET:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,15 @@ services:
       GF_SECURITY_ADMIN_USER: ${GF_SECURITY_ADMIN_USER}
       GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
       GF_SERVER_HTTP_PORT: ${GF_PORT:-3000}
-      GF_GITHUB_PLUGINS: "https://github.com/grafana/grafana-infinity-datasource/releases/download/v2.11.4/yesoreyeram-infinity-datasource-2.11.4.zip"
+      GF_GITHUB_PLUGINS: ${GF_GITHUB_PLUGINS:-"https://github.com/grafana/grafana-infinity-datasource/releases/download/v2.11.4/yesoreyeram-infinity-datasource-2.11.4.zip"}
       PROMETHEUS_URL: "http://${PROMETHEUS_TARGET:-localhost:9090}"
       ALERTMANAGER_URL: "http://${ALERTMANAGER_TARGET:-localhost:9093}"
       WALRUS_NODE_TARGET: ${WALRUS_NODE_TARGET:-}
       WALRUS_AGGREGATOR_TARGET: ${WALRUS_AGGREGATOR_TARGET:-}
       WALRUS_PUBLISHER_TARGET: ${WALRUS_PUBLISHER_TARGET:-}
       WALRUS_NODE_URL: ${WALRUS_NODE_URL}
+    env_file:
+      - ${GRAFANA_ENV_FILE:-/dev/null}
     volumes:
       - ./grafana/dashboards:/tmp/dashboards
       - ./grafana/provisioning:/etc/grafana/provisioning


### PR DESCRIPTION
This PR adds support for an optional Grafana configuration via an additional env file and makes the Grafana plugin list overridable from `.env`, without changing default behaviour for existing setups.

## Changes

- **Optional Grafana env file**: Grafana service uses `env_file: ${GRAFANA_ENV_FILE:-/dev/null}`. 
    - Unset or omit `GRAFANA_ENV_FILE` and behaviour is unchanged (no extra file). 
    - Set `GRAFANA_ENV_FILE=.grafana.env` in `.env` and create `.grafana.env` from `.grafana.env.tmp` to pass extra `GF_*` options to Grafana. 
    - `.grafana.env` is in `.gitignore`.
- **Overridable GF_GITHUB_PLUGINS**: In both `docker-compose.yml` and `docker-compose.macos.yml`, `GF_GITHUB_PLUGINS` is set via `${GF_GITHUB_PLUGINS:-"…"}` so it can be overridden in `.env` while keeping the same default plugin URL.
- **Docs**: README documents the optional Grafana customisation (copy `.grafana.env.tmp` → `.grafana.env`, set `GRAFANA_ENV_FILE=.grafana.env` in `.env`). Sample `.env` in README and `.env.tmp` include commented `GRAFANA_ENV_FILE` and (where relevant) `GF_GITHUB_PLUGINS`. Fixed typos and Grafana docs link text.

## Backwards compatibility

- No new required env vars or files.
- Default `GRAFANA_ENV_FILE` is `/dev/null`, so no file is required.
- `GF_GITHUB_PLUGINS` default is unchanged; only overrides are new.
- All existing `environment` vars remain and take precedence over the optional env file.